### PR TITLE
Leetcode[146. LRU Cache][Medium] Add solution

### DIFF
--- a/p146-lru-cache/README.md
+++ b/p146-lru-cache/README.md
@@ -1,0 +1,39 @@
+## [146. LRU Cache](https://leetcode.com/problems/lru-cache/)
+
+Design a data structure that follows the constraints of a Least Recently Used (LRU) cache.
+
+Implement the LRUCache class:
+
+- LRUCache(int capacity) Initialize the LRU cache with positive size capacity.
+- int get(int key) Return the value of the key if the key exists, otherwise return -1.
+- void put(int key, int value) Update the value of the key if the key exists. Otherwise, add the key-value pair to the cache. If the number of keys exceeds the capacity from this operation, evict the least recently used key.
+
+The functions get and put must each run in O(1) average time complexity.
+
+### Example 1:
+```
+Input
+["LRUCache", "put", "put", "get", "put", "get", "put", "get", "get", "get"]
+[[2], [1, 1], [2, 2], [1], [3, 3], [2], [4, 4], [1], [3], [4]]
+Output
+[null, null, null, 1, null, -1, null, -1, 3, 4]
+
+Explanation
+LRUCache lRUCache = new LRUCache(2);
+lRUCache.put(1, 1); // cache is {1=1}
+lRUCache.put(2, 2); // cache is {1=1, 2=2}
+lRUCache.get(1);    // return 1
+lRUCache.put(3, 3); // LRU key was 2, evicts key 2, cache is {1=1, 3=3}
+lRUCache.get(2);    // returns -1 (not found)
+lRUCache.put(4, 4); // LRU key was 1, evicts key 1, cache is {4=4, 3=3}
+lRUCache.get(1);    // return -1 (not found)
+lRUCache.get(3);    // return 3
+lRUCache.get(4);    // return 4
+```
+
+### Constraints:
+
+- 1 <= capacity <= 3000
+- 0 <= key <= 104
+- 0 <= value <= 105
+- At most 2 * 105 calls will be made to get and put.

--- a/p146-lru-cache/definition.go
+++ b/p146-lru-cache/definition.go
@@ -1,0 +1,1 @@
+package p146

--- a/p146-lru-cache/solution.go
+++ b/p146-lru-cache/solution.go
@@ -1,0 +1,98 @@
+package p146
+
+type Node struct {
+	Key, Val   int
+	Next, Prev *Node
+}
+
+type List struct {
+	Head, Tail *Node
+}
+
+func (l *List) MoveToFront(node *Node) {
+	if node == l.Head {
+		return
+	}
+
+	if node == l.Tail {
+		l.Tail = node.Prev
+	}
+
+	node.Prev.Next = node.Next
+	if node.Next != nil {
+		node.Next.Prev = node.Prev
+	}
+
+	node.Prev = nil
+	node.Next = l.Head
+	l.Head.Prev = node
+	l.Head = node
+}
+
+func (l *List) PushToFront(node *Node) {
+	if l.Head == nil {
+		l.Head, l.Tail = node, node
+		return
+	}
+	node.Next = l.Head
+	l.Head.Prev = node
+	l.Head = node
+}
+
+func (l *List) DelLastNode() *Node {
+	tail := l.Tail
+	if l.Head == l.Tail {
+		l.Head, l.Tail = nil, nil
+		return tail
+	}
+
+	l.Tail.Prev.Next = nil
+	l.Tail = l.Tail.Prev
+	tail.Prev = nil
+	return tail
+}
+
+type LRUCache struct {
+	keyAddr  map[int]*Node
+	capacity int
+	list     List
+}
+
+func Constructor(capacity int) LRUCache {
+	return LRUCache{keyAddr: make(map[int]*Node), capacity: capacity}
+}
+
+func (l *LRUCache) Get(key int) int {
+	node, ok := l.keyAddr[key]
+	if !ok {
+		return -1
+	}
+
+	l.list.MoveToFront(node)
+	return node.Val
+}
+
+func (l *LRUCache) Put(key int, value int) {
+	node, ok := l.keyAddr[key]
+	if ok {
+		node.Val = value
+		l.list.MoveToFront(node)
+		return
+	}
+
+	if len(l.keyAddr) >= l.capacity {
+		node := l.list.DelLastNode()
+		delete(l.keyAddr, node.Key)
+	}
+
+	node = &Node{Key: key, Val: value}
+	l.keyAddr[node.Key] = node
+	l.list.PushToFront(node)
+}
+
+/**
+ * Your LRUCache object will be instantiated and called as such:
+ * obj := Constructor(capacity);
+ * param_1 := obj.Get(key);
+ * obj.Put(key,value);
+ */


### PR DESCRIPTION
- Runtime: 556 ms, faster than 90% of Go online submissions for LRU Cache.
- Memory Usage: 80.2 MB, less than 43.18% of Go online submissions for LRU Cache.

Signed-off-by: oshankkumar <oshankfriends@gmail.com>